### PR TITLE
Add example for downloading CSVs from Google Drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # project2
+
+This repository includes a small Python utility to download multiple CSV files from Google Drive individually and load them with `pandas`.
+
+## Prerequisites
+
+- Python 3.7+
+- The [`gdown`](https://github.com/wkentaro/gdown) package for downloading from Google Drive.
+- The [`pandas`](https://pandas.pydata.org/) library for handling CSV files.
+
+Install the dependencies using pip:
+
+```bash
+pip install gdown pandas
+```
+
+## Usage
+
+1. Edit `download_csvs.py` and replace the placeholder `FILE_ID_*` values with the actual Google Drive file IDs for your CSV files.
+2. Run the script:
+
+```bash
+python download_csvs.py
+```
+
+Each file will be downloaded and loaded individually. The script prints the shape of each DataFrame as it is read.

--- a/download_csvs.py
+++ b/download_csvs.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import gdown
+
+# List of Google Drive file IDs for each CSV
+# Replace with your actual file IDs
+file_ids = [
+    'FILE_ID_1',
+    'FILE_ID_2',
+    'FILE_ID_3',
+]
+
+# Download each CSV individually and read into a DataFrame
+for file_id in file_ids:
+    url = f'https://drive.google.com/uc?id={file_id}'
+    output = f'{file_id}.csv'
+
+    # Download the file from Google Drive
+    gdown.download(url, output, quiet=False)
+
+    # Read the CSV into a DataFrame
+    df = pd.read_csv(output)
+    print(f'Loaded {output} with shape: {df.shape}')
+


### PR DESCRIPTION
## Summary
- add a helper `download_csvs.py` demonstrating how to download CSVs from Google Drive using `gdown`
- expand README with instructions on prerequisites and usage

## Testing
- `python download_csvs.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68545f1312888331ab44ada473b11c1d